### PR TITLE
extended the altKeyZoom method to accept specific modifiers,

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -1892,7 +1892,7 @@ dc_graph.diagram = function (parent, chartGroup) {
         var partial = bezier_point(points, end === 'tail' ? 0.25 : 0.75);
         return (end === 'head' ?
                 Math.atan2(tpos.y - partial.y, tpos.x - partial.x) :
-                Math.atan2(partial.y - spos.y, partial.x - spos.x)) + 'rad';
+                Math.atan2(spos.y - partial.y, spos.x - partial.x)) + 'rad';
     }
 
     function enforce_path_direction(path, spos, tpos) {

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -165,7 +165,7 @@ dc_graph.diagram = function (parent, chartGroup) {
      * @return {Boolean}
      * @return {dc_graph.diagram}
      **/
-    _chart.altKeyZoom = property(false);
+    _chart.modKeyZoom = _chart.altKeyZoom = property(false);
 
     /**
      * Set or get the fitting strategy for the canvas, which affects how the
@@ -2733,14 +2733,21 @@ dc_graph.diagram = function (parent, chartGroup) {
             .on('zoom', doZoom)
             .x(_chart.x()).y(_chart.y());
         if(_chart.mouseZoomable()) {
-            if(_chart.altKeyZoom()) {
+            var mod, mods;
+            if((mod = _chart.modKeyZoom())) {
+                if (Array.isArray (mod))
+                    mods = mod.slice ();
+                else if (typeof mod === "string")
+                    mods = [mod];
+                else
+                    mods = ['Alt'];
                 d3.select(document)
                     .on('keydown', function() {
-                        if(d3.event.key === 'Alt')
+                        if(mods.indexOf (d3.event.key) > -1)
                             enableZoom();
                     })
                     .on('keyup', function() {
-                        if(d3.event.key === 'Alt')
+                        if(mods.indexOf (d3.event.key) > -1)
                             disableZoom();
                     });
             }


### PR DESCRIPTION
not just the Alt key:
- still accepts true or false
- accepts the string representing a modifier, e.g. 'Alt'
- accepts an array of strings representing modifiers, e.g. ['Shift', 'Alt']
- made modKeyZoom a new alias for altKeyZoom